### PR TITLE
remove types/electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,6 @@
     "@types/chai-datetime": "0.0.30",
     "@types/classnames": "^0.0.32",
     "@types/codemirror": "0.0.38",
-    "@types/electron": "^1.4.36",
     "@types/electron-window-state": "^2.0.28",
     "@types/event-kit": "^1.2.28",
     "@types/fs-extra": "2.1.0",


### PR DESCRIPTION
according to npm, this is not needed

npm:
```npm WARN deprecated @types/electron@1.6.10: This is a stub types definition for electron (https://github.com/electron/electron). electron provides its own type definitions, so you don't need @types/electron installed!```
